### PR TITLE
[BUGFIX] Fix singleton bug

### DIFF
--- a/src/di.ts
+++ b/src/di.ts
@@ -4,9 +4,9 @@ import { logger } from './logger';
 import * as _ from 'lodash';
 import * as inversify from 'inversify';
 import ObjectFactory from './object-factory';
-
 import  { default as ObjectWrapper } from './object-wrapper';
-export { ObjectWrapper };
+
+export { ObjectWrapper, ObjectFactory };
 
 export namespace Di {
   const MetadataKeys = {


### PR DESCRIPTION
Fix singleton bug that was caused using two different object Factory classes at island and island-di ex) When using island.objectFactory.get and island-di.inject together, singleton instance does not work as expected