### PR TITLE
Changed default log level for npm test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
   - "6"
 
 install:
-  - npm install -g jasmine gulp typescript
+  - npm install -g jasmine gulp
   - npm install
 
 script:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-jasmine": "^2.4.1",
     "gulp-sourcemaps": "^1.6.0",
     "remap-istanbul": "^0.6.4",
-    "std-mocks": "^1.0.1"
+    "std-mocks": "^1.0.1",
+    "typescript": "<2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "gulp build",
     "watch": "gulp build && gulp watch",
     "clean": "gulp clean",
-    "test": "gulp build && DEBUG=* jasmine",
+    "test": "gulp build && DEBUG=* ISLAND_LOGGER_LEVEL=crit jasmine",
     "coverage": "gulp coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Background
- When run npm test, jasmine displays success/fail message on the screen
- It makes debugging hard 
- It can be solved by adding ISLAND_LOGGER_LEVEL front of {scripts: {test: "jasmine"}} in package.json file 

```
{
  "scripts": {
    "test": "gulp build && ISLAND_LOGGER_LEVEL=crit jasmine"
  }
}
```